### PR TITLE
Bring up-to-date with upstream

### DIFF
--- a/snmp/codenamemap.yaml
+++ b/snmp/codenamemap.yaml
@@ -1,0 +1,9 @@
+stretch:
+  # use the default OS parameters except for -LS6d (which was -Lsd)
+  snmpdargs: -LS6d -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf -f
+  # the value null means that the default OS parameters should be used
+  trapdargs: null
+  options: /etc/systemd/system/snmpd.service
+  optionstrap: /etc/systemd/system/snmptrapd.service
+  sourceoptions: salt://snmp/files/snmpd-systemd.options
+  sourceoptionstrap: salt://snmp/files/snmptrapd-systemd.options

--- a/snmp/conf.jinja
+++ b/snmp/conf.jinja
@@ -1,1 +1,2 @@
-{% set conf = salt['pillar.get']('snmp:conf', {}) %}
+{% from "snmp/map.jinja" import snmp with context %}
+{% set conf = snmp.get('conf', {}) -%}

--- a/snmp/conf.sls
+++ b/snmp/conf.sls
@@ -7,6 +7,7 @@ include:
 snmp_conf:
   file.managed:
     - name: {{ snmp.config }}
+    - makedirs: True
     - template: jinja
     - context:
       config: {{ conf.get('settings', {}) | json }}

--- a/snmp/conftrap.sls
+++ b/snmp/conftrap.sls
@@ -1,7 +1,7 @@
 {% from "snmp/map.jinja" import snmp with context %}
 
 include:
-  - snmp
+  - snmp.trap
 
 snmptrap_conf:
   file.managed:

--- a/snmp/files/snmpd-systemd.options
+++ b/snmp/files/snmpd-systemd.options
@@ -1,0 +1,18 @@
+# DO NOT EDIT
+#
+# This file is managed by Salt via {{ source }}
+# Modify the config that generates this file instead
+#
+{%- from "snmp/map.jinja" import snmp with context %}
+
+.include /lib/systemd/system/snmpd.service
+
+[Service]
+{%- if snmp.mibs is not none %}
+Environment="MIBS='{{ snmp.mibs }}'"
+{%- endif %}
+
+{%- if snmp.snmpdargs is not none %}
+ExecStart=
+ExecStart=/usr/sbin/snmpd {{ snmp.snmpdargs }}
+{%- endif %}

--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -183,8 +183,8 @@ access {{ entry.name }} {{ entry.context }} {{ entry.match }} {{ entry.level }} 
 # It is also possible to set the sysContact and sysLocation system
 # variables through the snmpd.conf file:
 
-syslocation "{{ conf.get('location', 'Unknown (add saltstack pillar)') }}"
-syscontact "{{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}"
+syslocation {{ conf.get('location', 'Unknown (add saltstack pillar)') }}
+syscontact {{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}
 
 # Example output of snmpwalk:
 #   % snmpwalk -v 1 localhost -c public system

--- a/snmp/files/snmpd.conf
+++ b/snmp/files/snmpd.conf
@@ -510,7 +510,7 @@ createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.get('a
 {%- endfor %}
 
 {% for declaration, values in config.items() %}
-{%- if values.__class__ in (().__class__, [].__class__) %}
+{%- if values | is_iter %}
     {%- for value in values %}
 {{declaration}} {{value}}
     {%- endfor %}

--- a/snmp/files/snmpd.conf.minimal
+++ b/snmp/files/snmpd.conf.minimal
@@ -83,7 +83,7 @@ createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.passph
 
 # Extra settings
 {% for declaration, values in config.items() %}
-{%- if values.__class__ in (().__class__, [].__class__) %}
+{%- if values | is_iter %}
     {%- for value in values %}
 {{declaration}} {{value}}
     {%- endfor %}

--- a/snmp/files/snmpd.conf.minimal
+++ b/snmp/files/snmpd.conf.minimal
@@ -16,8 +16,8 @@
 ##############################################################################
 # System contact information
 #
-sysLocation "{{ conf.get('location', 'Unknown (add saltstack pillar)') }}"
-sysContact "{{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}"
+sysLocation {{ conf.get('location', 'Unknown (add saltstack pillar)') }}
+sysContact {{ conf.get('syscontact', 'Root <root@localhost> (add saltstack pillar)') }}
 
 {% if conf.get('logconnects') is not none %}
 {%- if conf.get('logconnects') %}

--- a/snmp/files/snmptrapd-systemd.options
+++ b/snmp/files/snmptrapd-systemd.options
@@ -1,0 +1,14 @@
+# DO NOT EDIT
+#
+# This file is managed by Salt via {{ source }}
+# Modify the config that generates this file instead
+#
+{%- from "snmp/map.jinja" import snmp with context %}
+
+.include /lib/systemd/system/snmptrapd.service
+
+[Service]
+{%- if snmp.trapdargs is not none %}
+ExecStart=
+ExecStart=/usr/sbin/snmptrapd {{ snmp.trapdargs }}
+{%- endif %}

--- a/snmp/init.sls
+++ b/snmp/init.sls
@@ -9,7 +9,7 @@ snmp:
     - require:
       - pkg: {{ snmp.pkg }}
 
-{% if grains['os_family'] == 'Debian' %}
+{% if grains['os_family'] == 'Debian' and grains['osmajorrelease'] < 9 %}
 include:
   - snmp.default
 {% endif %}

--- a/snmp/macros.jinja
+++ b/snmp/macros.jinja
@@ -4,14 +4,14 @@
 {%- macro v12c_communities(mode, proto='') -%}
   {% set communities = conf.get(mode+'communities'+proto, []) -%}
   {%- for community in communities %}
-    {%- if communities.__class__ == {}.__class__ and communities.get(community, {}) is  mapping %}
+    {%- if communities is mapping and communities.get(community, {}) is  mapping %}
       {%- set source = communities.get(community).get('source', '') %}
       {%- set view = communities.get(community).get('view', None) %}
     {%- else %}
       {%- set source = '' %}
       {%- set view = '' %}
     {%- endif %}
-    {%- if not source.__class__ in (().__class__, [].__class__) %}
+    {%- if not source | is_iter %}
       {%- set source = [source] %}
     {%- endif %}
     {%- for src in source -%}

--- a/snmp/map.jinja
+++ b/snmp/map.jinja
@@ -1,4 +1,4 @@
-{# Debian uses snmpd init script for both snmpd/snmptrapd! #}
+{# Debian (up to and excluding 9.x 'Stretch') uses snmpd init script for both snmpd/snmptrapd! #}
 
 {% load_yaml as snmp %}
 service: snmpd
@@ -69,6 +69,12 @@ FreeBSD:
 
 {% if rhel_addition %}
     {% do snmp.update(rhel_addition) %}
+{% endif %}
+
+{% import_yaml "snmp/codenamemap.yaml" as codemap %}
+{% set oscode = salt['grains.filter_by'](codemap, grain='oscodename', default=None) %}
+{% if oscode is not none %}
+{%   do snmp.update(oscode) %}
 {% endif %}
 
 {% if user_override %}

--- a/snmp/optionstrap.sls
+++ b/snmp/optionstrap.sls
@@ -1,7 +1,7 @@
 {% from "snmp/map.jinja" import snmp with context %}
 
 include:
-  - snmp
+  - snmp.trap
 
 trap_options:
   file.managed:


### PR DESCRIPTION
We need #41 upstream to fix:

```
          ID: snmp_conf
    Function: file.managed
        Name: /etc/snmp/snmpd.conf
      Result: False
     Comment: Unable to manage file: Jinja syntax error: access to attribute '__class__' of 'list' object is unsafe.; line 513

              ---
              [...]
              rwuser {{ user.username }} {{ user.get('securitylevel', 'auth') }} -V {{ user.view }}
              createUser {{ user.username }} {{ user.get('authproto', 'MD5') }} {{ user.get('authpassphrase', user.passphrase) }} {{ user.get('privproto', 'AES') }} {{ user.get('privpassphrase', user.passphrase) }}
              {%- endfor %}

              {% for declaration, values in config.items() %}
              {%- if values.__class__ in (().__class__, [].__class__) %}    <======================
                  {%- for value in values %}
              {{declaration}} {{value}}
                  {%- endfor %}
              {%- else %}
              {{declaration}} {{values}}
              [...]
              ---
     Started: 11:41:34.775847
    Duration: 127.29 ms
     Changes:
```